### PR TITLE
ci: GH-2 Adding dependabot config for Actions and Gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Closes #2 

Adds daily updates for the `github-actions` and `gradle` dependencies