### PR TITLE
docs: GH-4 Adding README and ability to run specific classes through Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Advent of Code 2024
+
+Solutions to the puzzles from the [Advent of Code 2024](https://adventofcode.com/2024).
+
+## Getting started
+
+This project uses Java, so download and install a distribution of OpenJDK 23 or higher. 
+This can be acquired from [Oracle](https://jdk.java.net/23/) or through an IDE such as [IntelliJ IDEA](https://www.jetbrains.com/idea/download).
+
+Once loaded into your favourite IDE, run the build command;
+
+```shell
+./gradlew build
+```
+
+## Testing
+
+Tests can be run with;
+
+```shell
+./gradlew test
+```
+
+## Running a specific day's solution
+
+There's no single point of entry for the project, so each day's solution must be run with the following command;
+
+```shell
+./gradlew -PmainClass='org.aoc.<classname>' run
+```
+
+Where `classname` is the name of the solution to run. For example, to run Day 1, it would be;
+
+```shell
+./gradlew -PmainClass='org.aoc.Day1' run
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,10 @@
 plugins {
     id("java")
+    id("application")
+}
+
+application {
+    mainClass = if (project.hasProperty("mainClass")) project.property("mainClass").toString() else "NULL"
 }
 
 group = "org.aoc"


### PR DESCRIPTION
Closes #4 

Adds a README to the project, and also sets up the `application` plugin in Gradle to allow selecting a main class from the command line.